### PR TITLE
fix: fix signing transactions and add eth_call to Node provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@ethersproject/wallet": "^5.3.0",
     "buffer": "^6.0.3",
     "encoding": "^0.1.13",
+    "eth-sig-util": "^3.0.1",
     "jayson": "^3.4.4",
     "keccak256": "^1.0.2",
     "web3": "^1.3.4",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,8 +56,8 @@ export default class PolyjuiceHttpProviderForNode extends PolyjuiceHttpProvider 
     switch (method) {
       case "eth_sendTransaction":
         try {
-          const { from, gas, gasPrice, value, data, to } = params[0];
-
+          const { from, gas, gasPrice, value, data } = params[0];
+          const to = params[0].to || `0x${Array(40).fill(0).join('')}`;
           const data_with_short_address =
             await this.abi.refactor_data_with_short_address(
               data,

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -1,4 +1,4 @@
-const Accounts = require("web3-eth-accounts");
+import { personalSign } from 'eth-sig-util';
 
 declare global {
   interface Window {
@@ -30,15 +30,19 @@ export default class Signer {
     return _signature;
   }
 
-  // message with prefix "\x19Ethereum Signed Message:\n"
-  sign_with_private_key(message_with_prefix: string, address: string): string {
+  // message without prefix "\x19Ethereum Signed Message:\n"
+  sign_with_private_key(message_without_prefix: string, address: string): string {
     if (!this.private_key) {
       throw new Error("private key not found! cannot use this method!");
     }
 
-    const accounts = new Accounts();
-    const sign = accounts.sign(message_with_prefix, this.private_key);
-    return sign.signature;
+    let privateKeyBuffer = Buffer.from(this.private_key.length === 40 ? this.private_key : this.private_key.slice(2), 'hex');
+
+    const signature = personalSign(privateKeyBuffer, {
+      data: message_without_prefix
+    })
+
+    return signature;
   }
 
   // sign with other wallet...

--- a/src/util.ts
+++ b/src/util.ts
@@ -347,12 +347,13 @@ export class Godwoker {
   }
 
   async assembleRawL2Transaction(
-    eth_tx: EthTransaction
+    eth_tx: EthTransaction,
+    verboseLogs = false
   ): Promise<RawL2Transaction> {
     const from = await this.getAccountIdByEoaEthAddress(eth_tx.from);
     const to = await this.allTypeEthAddressToAccountId(eth_tx.to);
     const nonce = await this.getNonce(parseInt(from));
-    const encodedArgs = this.encodeArgs(eth_tx);
+    const encodedArgs = this.encodeArgs(eth_tx, verboseLogs);
     const tx: RawL2Transaction = {
       from_id: "0x" + BigInt(from).toString(16),
       to_id: "0x" + BigInt(to).toString(16),
@@ -509,13 +510,16 @@ export class Godwoker {
     });
   }
 
-  async waitForTransactionReceipt(tx_hash: Hash) {
+  async waitForTransactionReceipt(tx_hash: Hash, verboseLogs = false) {
     while (true) {
       await this.asyncSleep(3000);
       const tx_receipt = await this.eth_getTransactionReceipt(tx_hash);
-      console.log(
-        `keep waitting for tx_receipt: ${JSON.stringify(tx_receipt)}`
-      );
+
+      if (verboseLogs) {
+        console.log(
+          `keep waiting for tx_receipt: ${JSON.stringify(tx_receipt)}`
+        );
+      }
 
       if (tx_receipt) {
         break;
@@ -557,10 +561,12 @@ export class Godwoker {
     }
   }
 
-  encodeArgs(_tx: EthTransaction) {
+  encodeArgs(_tx: EthTransaction, verboseLogs = false) {
     const { to, gasPrice, gas: gasLimit, value, data } = _tx;
 
-    console.log(_tx);
+    if (verboseLogs) {
+      console.log(_tx);
+    }
     // header
     const args_0_7 =
       "0x" +

--- a/yarn.lock
+++ b/yarn.lock
@@ -2311,6 +2311,16 @@ eth-lib@^0.1.26:
     ws "^3.0.0"
     xhr-request-promise "^0.1.2"
 
+eth-sig-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-3.0.1.tgz#8753297c83a3f58346bd13547b59c4b2cd110c96"
+  integrity sha512-0Us50HiGGvZgjtWTyAI/+qTzYPMLy5Q451D0Xy68bxq1QMWdoOddDwGvsqcFT27uohKgalM9z/yxplyt+mY2iQ==
+  dependencies:
+    ethereumjs-abi "^0.6.8"
+    ethereumjs-util "^5.1.1"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.0"
+
 ethereum-bloom-filters@^1.0.6:
   version "1.0.9"
   resolved "https://registry.npm.taobao.org/ethereum-bloom-filters/download/ethereum-bloom-filters-1.0.9.tgz#4a59dead803af0c9e33834170bd7695df67061ec"
@@ -2339,6 +2349,14 @@ ethereum-cryptography@^0.1.3:
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
 
+ethereumjs-abi@^0.6.8:
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz#71bc152db099f70e62f108b7cdfca1b362c6fcae"
+  integrity sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==
+  dependencies:
+    bn.js "^4.11.8"
+    ethereumjs-util "^6.0.0"
+
 ethereumjs-common@^1.3.2, ethereumjs-common@^1.5.0:
   version "1.5.2"
   resolved "https://registry.nlark.com/ethereumjs-common/download/ethereumjs-common-1.5.2.tgz#2065dbe9214e850f2e955a80e650cb6999066979"
@@ -2351,6 +2369,19 @@ ethereumjs-tx@^2.1.1:
   dependencies:
     ethereumjs-common "^1.5.0"
     ethereumjs-util "^6.0.0"
+
+ethereumjs-util@^5.1.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz#a833f0e5fca7e5b361384dc76301a721f537bf65"
+  integrity sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==
+  dependencies:
+    bn.js "^4.11.0"
+    create-hash "^1.1.2"
+    elliptic "^6.5.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "^0.1.3"
+    rlp "^2.0.0"
+    safe-buffer "^5.1.1"
 
 ethereumjs-util@^6.0.0:
   version "6.2.1"
@@ -2373,7 +2404,7 @@ ethjs-unit@0.1.6:
     bn.js "4.11.6"
     number-to-bn "1.7.0"
 
-ethjs-util@0.1.6:
+ethjs-util@0.1.6, ethjs-util@^0.1.3:
   version "0.1.6"
   resolved "https://registry.npm.taobao.org/ethjs-util/download/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
   integrity sha1-8wi2Lxhfn+YjcTL7KpgYhmpc1TY=
@@ -4687,7 +4718,7 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rlp@^2.2.3:
+rlp@^2.0.0, rlp@^2.2.3:
   version "2.2.6"
   resolved "https://registry.npm.taobao.org/rlp/download/rlp-2.2.6.tgz#c80ba6266ac7a483ef1e69e8e2f056656de2fb2c"
   integrity sha1-yAumJmrHpIPvHmno4vBWZW3i+yw=
@@ -5327,10 +5358,20 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tweetnacl-util@^0.15.0:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
+  integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.npm.taobao.org/tweetnacl/download/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
 type-check@~0.3.2:
   version "0.3.2"


### PR DESCRIPTION
## Changes

1. Use `eth-sig-util` for adding personal prefix to message instead of custom function
2. Use `eth-sig-util` for signing instead of `web3-eth-accounts`
3. Add `eth_call` to Node.js provider
4. Fix smart-contract deployment by falling back to '0x000...0' address when 'to' is 'undefined'
5. Make `console.log` optional, because it's hard to read CLI program output when there are big debug logs

Tested and it works, while previous signing process produced: "internal error: invalid signature" for me.

## Problem

Before (error):
![image](https://user-images.githubusercontent.com/4950658/123317323-2ae82180-d52e-11eb-9f76-b6308681611c.png)

## Result

After (success, contract method called):
![image](https://user-images.githubusercontent.com/4950658/123317236-11df7080-d52e-11eb-879a-cd1c73cde8a0.png)

Video showing working CLI application in node.js (deployment+interaction) using this PR:
https://youtu.be/85Ku7tXbKX0

Log: https://gist.github.com/Kuzirashi/831df3a5a7e3f169caaec90f5d253374

Tested app: https://github.com/Kuzirashi/blockchain-workshop/tree/godwoken